### PR TITLE
Add locus_tag to GraphicRecord by default

### DIFF
--- a/dna_features_viewer/BiopythonTranslator/BiopythonTranslatorBase.py
+++ b/dna_features_viewer/BiopythonTranslator/BiopythonTranslatorBase.py
@@ -59,7 +59,10 @@ class BiopythonTranslatorBase:
     def compute_locus_tag(self, feature):
         """Compute the locus tag of the feature."""
         if 'locus_tag' in feature.qualifiers and len(feature.qualifiers['locus_tag']):
-            return feature.qualifiers['locus_tag']
+            locus_tag = feature.qualifiers['locus_tag']
+            if type(locus_tag) is list:
+                locus_tag = locus_tag[0]
+            return locus_tag
         else:
             return None
 

--- a/dna_features_viewer/BiopythonTranslator/BiopythonTranslatorBase.py
+++ b/dna_features_viewer/BiopythonTranslator/BiopythonTranslatorBase.py
@@ -59,9 +59,7 @@ class BiopythonTranslatorBase:
     def compute_locus_tag(self, feature):
         """Compute the locus tag of the feature."""
         if 'locus_tag' in feature.qualifiers and len(feature.qualifiers['locus_tag']):
-            locus_tag = feature.qualifiers['locus_tag']
-            if type(locus_tag) is list:
-                locus_tag = locus_tag[0]
+            locus_tag = feature.qualifiers['locus_tag'][0]
             return locus_tag
         else:
             return None

--- a/dna_features_viewer/BiopythonTranslator/BiopythonTranslatorBase.py
+++ b/dna_features_viewer/BiopythonTranslator/BiopythonTranslatorBase.py
@@ -33,6 +33,7 @@ class BiopythonTranslatorBase:
         """Translate a Biopython feature into a Dna Features Viewer feature."""
         properties = dict(
             label=self.compute_feature_label(feature),
+            locus_tag=self.compute_locus_tag(feature),
             color=self.compute_feature_color(feature),
             html=self.compute_feature_html(feature),
             fontdict=self.compute_feature_fontdict(feature),
@@ -54,6 +55,13 @@ class BiopythonTranslatorBase:
             strand=feature.location.strand,
             **properties
         )
+
+    def compute_locus_tag(self, feature):
+        """Compute the locus tag of the feature."""
+        if 'locus_tag' in feature.qualifiers and len(feature.qualifiers['locus_tag']):
+            return feature.qualifiers['locus_tag']
+        else:
+            return None
 
     def translate_record(self, record, record_class=None):
         """Create a new GraphicRecord from a BioPython Record object.

--- a/dna_features_viewer/GraphicFeature.py
+++ b/dna_features_viewer/GraphicFeature.py
@@ -17,6 +17,9 @@ class GraphicFeature:
     label
       Short descriptive text associated and plotted with the feature.
 
+    locus_tag
+      Locus tag of the feature
+
     color
       Color of the feature, any Matplotlib-compatible format is accepted,
       such as "white", "w", "#ffffff", (1,1,1), etc.
@@ -69,6 +72,7 @@ class GraphicFeature:
         end=None,
         strand=None,
         label=None,
+        locus_tag=None,
         color="#000080",
         thickness=14,
         linewidth=1.0,
@@ -87,6 +91,7 @@ class GraphicFeature:
         self.end = end
         self.strand = strand
         self.label = label
+        self.locus_tag = locus_tag
         self.color = color
         self.linecolor = linecolor
         self.data = data


### PR DESCRIPTION
I found locus_tag to be a useful property of GraphicFeature objects because it tends to be unique.