### PR TITLE
Compatibility with biopython 1.8.0 and bokeh 3

### DIFF
--- a/dna_features_viewer/GraphicRecord/BokehPlottableMixin.py
+++ b/dna_features_viewer/GraphicRecord/BokehPlottableMixin.py
@@ -92,8 +92,8 @@ class BokehPlottableMixin:
 
         # BUILD THE PLOT ()
         plot = figure(
-            plot_width=width,
-            plot_height=height,
+            width=width,
+            height=height,
             tools=tools,
             x_range=Range1d(0, self.sequence_length),
             y_range=Range1d(-1, max_y + 1),

--- a/dna_features_viewer/biotools.py
+++ b/dna_features_viewer/biotools.py
@@ -34,9 +34,17 @@ def reverse_complement(sequence):
     return complement(sequence)[::-1]
 
 
-aa_short_to_long_form_dict = {
-    _aa1: _aa3[0] + _aa3[1:].lower() for (_aa1, _aa3) in zip(aa1 + "*", aa3 + ["*"])
-}
+if type(aa1) is str and type(aa3) is list:
+    # biopython before 1.8.0
+    aa_short_to_long_form_dict = {
+        _aa1: _aa3[0] + _aa3[1:].lower() for (_aa1, _aa3) in zip(aa1 + "*", aa3 + ["*"])
+    }
+else:
+    # biopython 1.8.0 and later
+    # relevant commit: https://github.com/biopython/biopython/commit/257143be9196b77619d3d8cadc22039212681e08
+    aa_short_to_long_form_dict = {
+        _aa1: _aa3[0] + _aa3[1:].lower() for (_aa1, _aa3) in zip(aa1 + ('*',), aa3 + ('*',))
+    }
 
 
 def translate(dna_sequence, long_form=False):
@@ -123,7 +131,7 @@ def load_record(path, filetype=None):
 
 
 def annotate_biopython_record(
-    seqrecord, location="full", feature_type="misc_feature", margin=0, **qualifiers
+        seqrecord, location="full", feature_type="misc_feature", margin=0, **qualifiers
 ):
     """Add a feature to a Biopython SeqRecord.
 


### PR DESCRIPTION
These fixes make DnaFeaturesViewer compatible with:

- bokeh 3
- biopython 1.80

This breaks compatibility with bokeh 2.4.3 and lower.

It is still compatible with older biopython