### PR TITLE
To fix the concatenation error

### DIFF
--- a/dna_features_viewer/biotools.py
+++ b/dna_features_viewer/biotools.py
@@ -35,7 +35,7 @@ def reverse_complement(sequence):
 
 
 aa_short_to_long_form_dict = {
-    _aa1: _aa3[0] + _aa3[1:].lower() for (_aa1, _aa3) in zip(aa1 + "*", aa3 + ["*"])
+    _aa1: _aa3[0] + _aa3[1:].lower() for (_aa1, _aa3) in zip(list(aa1) + ["*"], list(aa3) + ["*"])
 }
 
 


### PR DESCRIPTION
When `dna_features_viewer` (installed from pypi v3.1.1) was imported, using this command: `import dna_features_viewer`, it produced concatenation errors:
1. `TypeError: can only concatenate tuple (not "str") to tuple` because tuple called `aa1` was being concatenated to a string `'*'`, and 
2. `TypeError: can only concatenate tuple (not "list") to tuple` because tuple called `aa3` was being concatenated to a list `['*']`.

The suggested modification — where respective tuples and strings are converted to lists before concatenation — should fix these errors.