### PR TITLE
Remove Biopython requirement

### DIFF
--- a/dna_features_viewer/GraphicRecord/GraphicRecord.py
+++ b/dna_features_viewer/GraphicRecord/GraphicRecord.py
@@ -1,19 +1,6 @@
 # -*- coding: utf-8 -*-
 from ..biotools import find_narrowest_text_wrap
 
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
-from Bio.SeqFeature import FeatureLocation, SeqFeature
-
-try:
-    # Biopython <1.78
-    from Bio.Alphabet import DNAAlphabet
-
-    has_dna_alphabet = True
-except ImportError:
-    # Biopython >=1.78
-    has_dna_alphabet = False
-
 from .MatplotlibPlottableMixin import MatplotlibPlottableMixin
 from .BokehPlottableMixin import BokehPlottableMixin
 
@@ -123,6 +110,22 @@ class GraphicRecord(MatplotlibPlottableMixin, BokehPlottableMixin):
         with open("example.gb", "w+") as f:
             SeqIO.write(record, f, "genbank")
         """
+        try:
+            from Bio.Seq import Seq
+            from Bio.SeqRecord import SeqRecord
+            from Bio.SeqFeature import FeatureLocation, SeqFeature
+        except ImportError as ex:
+            raise ImportError("Please install the Biopython library to use this functionality") from ex
+        try:
+            # Biopython <1.78
+            from Bio.Alphabet import DNAAlphabet
+
+            has_dna_alphabet = True
+        except ImportError:
+            # Biopython >=1.78
+            has_dna_alphabet = False
+
+
         features = [
             SeqFeature(
                 FeatureLocation(f.start, f.end, f.strand),

--- a/dna_features_viewer/biotools.py
+++ b/dna_features_viewer/biotools.py
@@ -1,9 +1,17 @@
 import textwrap
-from Bio.Seq import Seq
-from Bio.SeqFeature import SeqFeature, FeatureLocation
-from Bio.PDB.Polypeptide import aa1, aa3
-from Bio import SeqIO
 
+try:
+    from Bio.Seq import Seq
+    from Bio.SeqFeature import SeqFeature, FeatureLocation
+    from Bio.PDB.Polypeptide import aa1, aa3
+    from Bio import SeqIO
+except ImportError:
+    class Seq:
+        def __init__(*a, **kw):
+            raise ImportError("Please install the Biopython library to use this functionality")
+    FeatureLocation = SeqIO = SeqFeature = Seq
+    SeqIO.read = SeqIO.__init__
+    aa1 = aa3 = None
 try:
     from BCBio import GFF
 except ImportError:
@@ -39,7 +47,7 @@ if type(aa1) is str and type(aa3) is list:
     aa_short_to_long_form_dict = {
         _aa1: _aa3[0] + _aa3[1:].lower() for (_aa1, _aa3) in zip(aa1 + "*", aa3 + ["*"])
     }
-else:
+elif aa1 is not None:
     # type is tuple
     # biopython 1.80 and later
     # See issue #73

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     license="MIT",
     keywords="DNA Sequence Feature Genbank Biopython Matplotlib",
     packages=find_packages(exclude="docs"),
-    install_requires=["matplotlib>=3", "Biopython", "packaging"],
+    install_requires=["matplotlib>=3", "packaging"],
 )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -12,10 +12,9 @@ from dna_features_viewer import (
     annotate_biopython_record,
     load_record,
 )
-from bokeh.resources import CDN
-from bokeh.embed import file_html
 from Bio import SeqIO
 import numpy as np
+import pytest
 
 matplotlib.use("Agg")
 
@@ -114,6 +113,9 @@ def test_plot_with_gc_content(tmpdir):
 
 
 def test_plot_with_bokeh(tmpdir):
+    pytest.importorskip('bokeh', reason='require bokeh module')
+    from bokeh.resources import CDN
+    from bokeh.embed import file_html
     gb_record = SeqIO.read(example_genbank, "genbank")
     record = BiopythonTranslator().translate_record(record=gb_record)
     plot = record.plot_with_bokeh(figure_width=8)
@@ -126,6 +128,9 @@ def test_plot_with_bokeh(tmpdir):
 
 def test_plot_with_bokeh_no_labels(tmpdir):
     """Bokeh has a problem with empty lists of labels."""
+    pytest.importorskip('bokeh', reason='require bokeh module')
+    from bokeh.resources import CDN
+    from bokeh.embed import file_html
     gb_record = SeqIO.read(example_genbank, "genbank")
     record = BiopythonTranslator().translate_record(record=gb_record)
     for feature in record.features:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -244,6 +244,7 @@ def test_BlackBoxlessLabelTranslator(tmpdir):
 
 
 def test_gff():
+    pytest.importorskip('bcbio-gff', reason='require bcbio-gff module')
     translator = BlackBoxlessLabelTranslator()
     graphic_record = translator.translate_record(example_gff)
     assert len(graphic_record.features) == 3

--- a/tests/test_biotools.py
+++ b/tests/test_biotools.py
@@ -1,4 +1,5 @@
 import textwrap
+import pytest
 from dna_features_viewer.biotools import (
     extract_graphical_translation,
     reverse_complement,
@@ -7,6 +8,7 @@ from dna_features_viewer.biotools import (
 
 
 def test_extract_graphical_translation():
+    pytest.importorskip('Bio')
     seq = "ATGGACAGAACAATATAA"
     seq1 = "ATGC" + seq + "GTTC"
     seq2 = "ATGC" + reverse_complement(seq) + "GTTC"


### PR DESCRIPTION
Hi, thanks for this nice package which I found quite useful!
I am using it in a small library for [plotting features](https://rnajena-sugar.readthedocs.io/en/latest/src/tutorial_imaging.html#plotting-features).

In my use case, I bring my own IO routines, so that the code requiring biopython is not used. Other projetcs could use the same approach and call GraphicFeature etc. directly. I think it would be nice, if the biopython requirement was optional. Hence this PR as a starting point for discussion.